### PR TITLE
404 page

### DIFF
--- a/src/app/(frontend)/[...not-found]/page.tsx
+++ b/src/app/(frontend)/[...not-found]/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from "next/navigation";
+
+export default function HandleNotFound() {
+    notFound();
+}

--- a/src/app/(frontend)/not-found.tsx
+++ b/src/app/(frontend)/not-found.tsx
@@ -1,7 +1,14 @@
+import Button from "@ui/button/Button";
+
 export default function NotFound() {
   return (
-    <div className="flex items-center justify-center min-h-screen bg-black text-white text-2xl">
-      404 - Page Not Found
+    <div className="flex items-center justify-center min-h-screen bg-black text-white text-lg">
+      <div className="flex flex-col items-center justify-center gap-10">
+        <h3>404 - Page Not Found</h3>
+        <Button href="/" variant={{ style: "solid" }}>
+          Return Home
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/app/(frontend)/not-found.tsx
+++ b/src/app/(frontend)/not-found.tsx
@@ -1,0 +1,7 @@
+export default function NotFound() {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-black text-white text-2xl">
+      404 - Page Not Found
+    </div>
+  );
+}


### PR DESCRIPTION
### Linked Issue
Closes #43 

### Summary
Implements a custom 404 page

### Changes Made
- Added `not-found.tsx` under `src/app/(frontend)/` with simple layout and message (no figma reference provided)
- Added `[...not-found]/page.tsx` as a catch-all route to trigger 404 page
- Included a "Return Home" button using the `Button` component

<img width="956" alt="image" src="https://github.com/user-attachments/assets/89369b24-3cb8-4bfa-acd4-c6465596dc20" />
