### PR TITLE
refactor: api wrapper to include context

### DIFF
--- a/src/app/api/(Sandbox)/public/[testId]/[AAAAA]/route.ts
+++ b/src/app/api/(Sandbox)/public/[testId]/[AAAAA]/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { RouteContext, routeWrapper } from "@libs/api/wrappers";
+
+export const GET = routeWrapper(async (req, session, context: RouteContext<"testId" | "AAAAA">) => {
+    const { AAAAA, testId } = await context?.params;
+
+    return NextResponse.json({
+        message: "Hello from Next.js! This is a public route",
+        session,
+        testId,
+        AAAAA,
+        req,
+    });
+});

--- a/src/app/api/(Sandbox)/public/[testId]/route.ts
+++ b/src/app/api/(Sandbox)/public/[testId]/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { RouteContext, routeWrapper } from "@libs/api/wrappers";
+
+export const GET = routeWrapper(async (req, session, context: RouteContext<"testId">) => {
+    const { testId } = await context.params;
+
+    return NextResponse.json({
+        message: "Hello from Next.js! This is a public route",
+        session,
+        testId,
+        req,
+    });
+});

--- a/src/app/api/(Sandbox)/public/membershipStatus/[userId]/route.ts
+++ b/src/app/api/(Sandbox)/public/membershipStatus/[userId]/route.ts
@@ -1,21 +1,21 @@
 "use server";
 
+import { NextRequest, NextResponse } from "next/server";
 import { db } from "@libs/db";
 import { memberships, membershipTypes, profiles } from "@libs/db/schema";
-import { eq, and } from "drizzle-orm";
-import { NextResponse, NextRequest } from "next/server";
+import { and, eq } from "drizzle-orm";
 
 // a member is valid if there is a single active membership (current time is between a membership)
 // the membership must be paid for it to be valid
 // should return boolean
 export const GET = async (
     req: NextRequest,
-    { params }: { params: Promise<{ userId: string }> }
-  ) => {
-    const {userId} = await params;
+    { params }: { params: Promise<{ userId: string }> },
+) => {
+    const { userId } = await params;
 
     console.log("userId", userId);
-    
+
     // Find the user's profile
     // Selects id from profiles schema where userId matches the provided userId
     // To get profileId, which is just called id in the profiles schema
@@ -28,7 +28,7 @@ export const GET = async (
     console.log("profile", profile);
 
     if (!profile[0]) return NextResponse.json({ body: false });
-    
+
     // const profileIda = await db.select().from(profiles).where(eq(profiles.userId, userId))
     // .innerjoin(profiles, eq(users.id, profiles.id))
 
@@ -40,12 +40,7 @@ export const GET = async (
             membershipTypeId: memberships.membershipTypeId,
         })
         .from(memberships)
-        .where(
-            and(
-                eq(memberships.profileId, profile[0].id),
-                eq(memberships.isPaid, true)
-            )
-        );
+        .where(and(eq(memberships.profileId, profile[0].id), eq(memberships.isPaid, true)));
 
     console.log("membership", membership);
     if (!membership[0]) return NextResponse.json({ body: false });
@@ -68,6 +63,6 @@ export const GET = async (
     const startAt = new Date(membershipType[0].startAt);
     const endAt = new Date(membershipType[0].endAt);
 
-    const isMember =  now >= startAt && now <= endAt;
+    const isMember = now >= startAt && now <= endAt;
     return NextResponse.json({ body: isMember });
-}
+};

--- a/src/app/api/(Sandbox)/public/route.ts
+++ b/src/app/api/(Sandbox)/public/route.ts
@@ -1,6 +1,27 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { routeWrapper } from "@libs/api/wrappers";
 
-export const GET = routeWrapper(async (req, session) => {
-    return NextResponse.json({ message: "Hello from Next.js! This is a public route", session });
+export const GET = routeWrapper(async (req: NextRequest, session, context) => {
+    const cookie = req.cookies.getAll();
+    const path = req.nextUrl.pathname;
+    const search = req.nextUrl.search;
+    const searchParams = req.nextUrl.searchParams;
+    const allSearchParams = Object.fromEntries(searchParams.entries());
+
+    const res = NextResponse.json({
+        message: "Hello from Next.js! This is a public route",
+        session,
+        cookie,
+        path,
+        search,
+        searchParam: allSearchParams,
+        context,
+    });
+
+    res.cookies.set("AAAAAAAA", "AAAAAAAAAAAAAAAAA", {
+        httpOnly: true, // optional
+        path: "/",
+    });
+
+    return res;
 });


### PR DESCRIPTION
api wrapper is an api wrapper to include session built it, when it was initially created there was a slight oversight that made it not possible to include route context from a dynamic path.

this pr upgrades the wrapper to include route context 

- refactor `wrapper.ts`
- route context typing via `RouteContext<"aParam">`

usage:
`/api/[profileId]`
```ts
export const GET = routeWrapper(async (req, session, context: RouteContext<"profileId">) => {
    const { profileId } = await context.params;
}
```